### PR TITLE
chore(ci): bump actions for Node 24 runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,5 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: actions/setup-node@v6
-              with:
-                  node-version: 20
             - run: npm install
             - run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,8 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 20
             - run: npm install


### PR DESCRIPTION
## Summary

Bumps GitHub Actions to versions compatible with the Node 24 runtime, and removes the hardcoded `node-version: 20` pin.

| Change | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `node-version` pin | 20 (hardcoded) | removed (uses project default) |

## Test plan
- [ ] Verify lint workflow runs successfully on next PR